### PR TITLE
Add an API for WarningScreens.

### DIFF
--- a/MTM101BMDE/AssetManager/AssetLoader.cs
+++ b/MTM101BMDE/AssetManager/AssetLoader.cs
@@ -16,7 +16,25 @@ namespace MTM101BaldAPI.AssetTools
 {
     public static class AssetLoader
     {
+        /// <summary>
+        /// Will show a warning screen telling the user to install the mod correctly
+        /// if the folder for the specified plugin is not found in Modded.
+        /// </summary>
+        public static void AssertAssetsFolder(BaseUnityPlugin plug)
+        {
+            string assetsPath = GetModPath(plug);
+            if (!Directory.Exists(assetsPath))
+            {
+                MTM101BaldiDevAPI.ShowWarningScreen(String.Format(@"
+The mod <color=blue>{0}</color> must have the assets file in <color=red>StreamingAssets/Modded</color>!</color>
 
+The name of the assets folder must be <color=red>{1}</color>.
+
+
+<alpha=#AA>PRESS ALT + F4 TO CLOSE THIS GAME
+", Path.GetFileName(plug.Info.Location), plug.Info.Metadata.GUID));
+            }
+        }
         public static Texture2D TextureFromFile(string path)
         {
             return TextureFromFile(path, TextureFormat.RGBA32);

--- a/MTM101BMDE/AssetManager/AssetLoader.cs
+++ b/MTM101BMDE/AssetManager/AssetLoader.cs
@@ -35,6 +35,43 @@ The name of the assets folder must be <color=red>{1}</color>.
 ", Path.GetFileName(plug.Info.Location), plug.Info.Metadata.GUID));
             }
         }
+
+        /// <summary>
+        /// Load textures from a pattern, used to easily load texture animations.
+        /// <para>
+        /// <code>
+        /// // Example : 
+        /// AssetLoader
+        ///     .TexturesFromMod(FoxoPlugin.Instance, "foxo/slap{0}.png", (1, 4))
+        ///     .ToSprites(PIXELS_PER_UNIT)
+        /// </code>
+        /// </para>
+        /// </summary>
+        /// <param name="mod">The plugin instance</param>
+        /// <param name="pattern">A pattern that will go through String.Format(pattern, i)</param>
+        /// <param name="range">Inclusive minimum and maximum range (start, end)</param>
+        /// <returns></returns>
+        public static Texture2D[] TexturesFromMod(BaseUnityPlugin mod, string pattern, (int, int) range)
+        {
+            var textures = new List<Texture2D>();
+            for (int i = range.Item1; i <= range.Item2; i++)
+            {
+                textures.Add(TextureFromMod(mod, string.Format(pattern, i)));
+            }
+            return textures.ToArray();
+        }
+
+        /// <summary>
+        /// Convert an array of texture into sprites
+        /// </summary>
+        /// <param name="textures"></param>
+        /// <param name="pixelsPerUnit"></param>
+        /// <returns></returns>
+        public static Sprite[] ToSprites(this Texture2D[] textures, float pixelsPerUnit)
+        {
+            return (from tex in textures select SpriteFromTexture2D(tex, pixelsPerUnit)).ToArray();
+        }
+
         public static Texture2D TextureFromFile(string path)
         {
             return TextureFromFile(path, TextureFormat.RGBA32);

--- a/MTM101BMDE/BasePlugin.cs
+++ b/MTM101BMDE/BasePlugin.cs
@@ -24,6 +24,7 @@ using System.Collections;
 using MTM101BaldAPI.UI;
 using UnityEngine.UI;
 using MidiPlayerTK;
+using MTM101BaldAPI.Patches;
 
 namespace MTM101BaldAPI
 {
@@ -364,6 +365,27 @@ namespace MTM101BaldAPI
             AssetMan.Add<SoundObject>("Xylophone", allSoundObjects.Where(x => x.name == "Xylophone").First());
             AssetMan.Add<SoundObject>("Explosion", allSoundObjects.Where(x => x.name == "Explosion").First());
             AssetMan.AddFromResources<TMPro.TMP_FontAsset>();
+        }
+
+        /// <summary>
+        /// <para>
+        /// Switch the scene to Warnings and changes its text to the one defined in the arguments.
+        /// Useful for showing critical errors that originates from an end user mistake and providing instructions to fix it.
+        /// </para>
+        /// 
+        /// <para>
+        /// If you want to check if the assets directory of your mod is correctly placed,
+        /// use <seealso cref="AssetLoader.AssertAssetsFolder(BaseUnityPlugin)"/> instead.
+        /// </para>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// The Warning Screen can't be advanced.
+        /// </remarks>
+        /// <param name="text"></param>
+        public static void ShowWarningScreen(string text)
+        {
+            WarningScreenCustomText.ShowWarningScreen(text);
         }
 
         // "GUYS IM GONNA USE THIS FOR MY CUSTOM ERROR SCREEN FOR MY FUNNY 4TH WALL BREAK IN MY MOD!"

--- a/MTM101BMDE/Patches/WarningScreenPatches.cs
+++ b/MTM101BMDE/Patches/WarningScreenPatches.cs
@@ -1,0 +1,37 @@
+﻿using HarmonyLib;
+using UnityEngine.SceneManagement;
+
+namespace MTM101BaldAPI.Patches
+{
+    [HarmonyPatch(typeof(WarningScreen), "Start")]
+    internal class WarningScreenCustomText
+    {
+        internal static bool preventAdvance = false;
+        private static string forceText = null;
+
+        internal static bool Prefix(WarningScreen __instance)
+        {
+            if (forceText != null)
+            {
+                __instance.textBox.SetText(forceText);
+            }
+            if (preventAdvance)
+            {
+                // Returning false will prevent Baldi to format the text to "Click button to continue"
+                return false;
+            }
+            return true;
+        }
+        internal static void ShowWarningScreen(string text)
+        {
+            forceText = text;
+            preventAdvance = true;
+            SceneManager.LoadScene("Warnings");
+        }
+    }
+    [HarmonyPatch(typeof(WarningScreen), "Advance")]
+    internal class WarningScreenPreventAdvance
+    {
+        internal static bool Prefix() => !WarningScreenCustomText.preventAdvance;
+    }
+}

--- a/MTM101BMDE/Patches/WarningScreenPatches.cs
+++ b/MTM101BMDE/Patches/WarningScreenPatches.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 namespace MTM101BaldAPI.Patches
 {
     [HarmonyPatch(typeof(WarningScreen), "Start")]
+    [HarmonyPriority(800)]
     internal class WarningScreenCustomText
     {
         internal static bool preventAdvance = false;
@@ -30,6 +31,7 @@ namespace MTM101BaldAPI.Patches
         }
     }
     [HarmonyPatch(typeof(WarningScreen), "Advance")]
+    [HarmonyPriority(800)]
     internal class WarningScreenPreventAdvance
     {
         internal static bool Prefix() => !WarningScreenCustomText.preventAdvance;

--- a/MTM101BMDE/Registers/GeneratorManagement.cs
+++ b/MTM101BMDE/Registers/GeneratorManagement.cs
@@ -8,9 +8,25 @@ namespace MTM101BaldAPI.Registers
 {
     public enum GenerationModType
     {
+        /// <summary>
+        /// This should be used for methods that override the majority of the generator properties, almost completely transforming the level.
+        /// </summary>
         Base, // runs first, expected to override everything
+
+        /// <summary>
+        /// This should be used for overriding only certain properties of the generator, such as changing exit counts.
+        /// </summary>
         Override, // overrides specific variables, such as items and whatnot
+
+        /// <summary>
+        /// This should be used for adding onto already existing properties, such as adding characters or items. Most mods will be using this.
+        /// </summary>
         Addend, // adds to already existing fields, such as adding new items
+
+        /// <summary>
+        /// Useful for removing things that might've been added or changed by other mods, or if for one reason or another you need the final say on something. 
+        /// <c>Use with caution.</c>
+        /// </summary>
         Finalizer // runs last, useful for subtracting/removing things or if you REALLY need the last say, use with caution!
     }
 


### PR DESCRIPTION
## Changes
The changes include two methods `AssetLoader.AssertAssetsFolder(BaseUnityPlugin plug)` and `MTM101BaldAPI.ShowWarningScreen(string text)`. It's an alternative to CauseCrash without involving exceptions!

It's also XML documented (Don't forget to include XML files in the next releases of the mod for other developers)! And includes other goodies.

A simple `AssetLoader.AssertAssetsFolder(this)` called in the Awake method of your mod can spare a ton of "why i see beans help plzz" comments.

## Why ?
Because I use this in my mods, people keep misreading the instructions for installing properly a mod. Or sometimes they keep breaking the mod themselves.

The CauseCrash method is good for exceptions and to prompt the users to report this, but not for providing clear instructions to the users to fix themselves a simple mistake. This is very helpful for this kind of scenario :
![image](https://github.com/benjaminpants/MTM101BMDE/assets/55030860/37fcb74c-2df9-4b14-8a73-bd5f280af40e)
![image](https://github.com/benjaminpants/MTM101BMDE/assets/55030860/4aa2ccbb-e5c2-4ff8-986d-b1b08b2c7e4a)

## Limitations
The ShowWarningScreen method will make the WarningScreen not advanceable/skippable until that the game is restarted. It's intended for critical errors, not for adding custom messages in the beginning of the game. It's not intended either to be a lazy way to restart the game.

## Preview
An example of `AssetLoader.AssertAssetsFolder(this)` called in Awake of the Modding API. Will automatically fetch the name of the assets folder and the dll causing the issue.
![image](https://github.com/benjaminpants/MTM101BMDE/assets/55030860/19d58ed8-78af-49e0-82a8-26f1ff9a8454)

An example of `MTM101BaldAPI.ShowWarningScreen("This is a test warning screen!")`.
![image](https://github.com/benjaminpants/MTM101BMDE/assets/55030860/9840bb94-cb5b-48de-92b6-a2f8deb55bba)
