### PR TITLE
Changed one line in MTLLoader

### DIFF
--- a/MTM101BMDE/OBJImport/MTLLoader.cs
+++ b/MTM101BMDE/OBJImport/MTLLoader.cs
@@ -170,7 +170,7 @@ public class MTLLoader {
                 }
                 else
                 {
-                    baseMaterial = new Material(MTM101BaldiDevAPI.AssetMan.Get<Material>("TileBase")) { name = materialName };
+                    newMtl = new Material(MTM101BaldiDevAPI.AssetMan.Get<Material>("TileBase")) { name = materialName };
                 }
                 mtlDict[materialName] = newMtl;
                 currentMaterial = newMtl;


### PR DESCRIPTION
`newMtl` assignment instead of `baseMaterial` (fixes the `null` assignment to the dictionary).