### PR TITLE
Prevent Window Title changes in different platforms

### DIFF
--- a/MTM101BMDE/BasePlugin.cs
+++ b/MTM101BMDE/BasePlugin.cs
@@ -849,7 +849,7 @@ PRESS ALT+F4 TO EXIT THE GAME.
             allowWindowTitleChange = Config.Bind("Technical",
                 "Allow Window Title Change",
                 true,
-                "Allow the API to change the game's window title to reflect the fact that it's been modded.");
+                "Allow the API to change the game's window title to reflect the fact that it's been modded.\nOnly works on Windows systems.");
 
             usingMidiFix = Config.Bind("Technical",
                 "Use Midi Fix",
@@ -900,10 +900,7 @@ PRESS ALT+F4 TO EXIT THE GAME.
             }
 
             //set window title
-            if (allowWindowTitleChange.Value)
-            {
-                WindowTitle.SetText(Application.productName + " (Modded)");
-            }
+            WindowTitle.SetText(Application.productName + " (Modded)");
         }
     }
 

--- a/MTM101BMDE/WindowTitle.cs
+++ b/MTM101BMDE/WindowTitle.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace MTM101BaldAPI
 {
-    public class WindowTitle
+    public static class WindowTitle
     {
         private delegate bool EnumThreadDelegate(IntPtr hwnd, IntPtr lParam);
 
@@ -30,11 +28,25 @@ namespace MTM101BaldAPI
         [DllImport("user32.dll", EntryPoint = "SetWindowText")]
         private static extern bool SetWindowText(System.IntPtr hwnd, System.String lpString);
 
-        //SET FUNCTION
-        public static void SetText(string text)
+        private static void SetTextInternal(string text)
         {
             System.IntPtr handle = GetWindowHandle();
             SetWindowText(handle, text);
+        }
+
+        private static bool osChecked = false;
+        private static bool enabled;
+
+        //SET FUNCTION
+        public static void SetText(string text)
+        {
+            if (!osChecked)
+            {
+                osChecked = true;
+                enabled = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && MTM101BaldiDevAPI.Instance.allowWindowTitleChange.Value;
+            }
+            if (enabled)
+                SetTextInternal(text);
         }
     }
 }


### PR DESCRIPTION
This is due to the nature of the feature relying on the Windows API and this addition might affect other platforms as-is, especially when other mods might start using it.