### PR TITLE
`LoadAngledAnimations` has an overlooked situation and causes animation's length to be slowed down depending on the length of the array.

### DIFF
--- a/MTM101BMDE/Components/Animation/CustomAnimatorClasses.cs
+++ b/MTM101BMDE/Components/Animation/CustomAnimatorClasses.cs
@@ -193,7 +193,7 @@ namespace MTM101BaldAPI.Components.Animation
         {
             this.animations = new Dictionary<string, SpriteAnimation>();
             foreach (var animation in animations)
-                this.animations.Add(animation.Key, new SpriteAnimation(AddAngledAnimation(animation.Value.angleCount, animation.Value.frames.Select(x => x.value).ToList()).ToArray(), animation.Value.animationLength));
+                this.animations.Add(animation.Key, new SpriteAnimation(AddAngledAnimation(animation.Value.angleCount, animation.Value.frames.Select(x => x.value).ToList()).ToArray(), animation.Value.animationLength / animation.Value.angleCount));
         }
 
         public void SetSpriteRenderer(SpriteRenderer sprRenderer) => _renderer.SetValue(renderer, sprRenderer);


### PR DESCRIPTION
One simple hotfix, I encountered this while porting Events Overloaded to v0.14.X.