### PR TITLE
Baldi TV Fix

### DIFF
--- a/MTM101BMDE/PlusExtensions/BaldiTVExtensions.cs
+++ b/MTM101BMDE/PlusExtensions/BaldiTVExtensions.cs
@@ -45,13 +45,15 @@ namespace MTM101BaldAPI.PlusExtensions
             if (id == "baldi") return BaldiSpeaksWrapper(tv);
             // create image
             // todo: i should probably just create this instead of copying BaldiTV
-            Image clonedImage = GameObject.Instantiate<Image>((Image)_baldiImage.GetValue(tv), tv.transform);
-            clonedImage.name = id + "_Image";
+            Image baldiImage = (Image)_baldiImage.GetValue(tv);
+            Image clonedImage = GameObject.Instantiate(baldiImage, MTM101BaldiDevAPI.prefabTransform, true); // Fix from AlexBW145: this method is a hack but apparently because I made it a prefab before sending it into the real game.
             clonedImage.gameObject.SetActive(true);
-            GameObject.Destroy(clonedImage.GetComponent<VolumeAnimator>());
-            GameObject.Destroy(clonedImage.GetComponent<Animator>());
-            GameObject.Destroy(clonedImage.GetComponent<AudioSource>());
-            GameObject.Destroy(clonedImage.GetComponent<AudioManager>());
+            GameObject.DestroyImmediate(clonedImage.GetComponent<VolumeAnimator>());
+            GameObject.DestroyImmediate(clonedImage.GetComponent<Animator>());
+            GameObject.DestroyImmediate(clonedImage.GetComponent<AudioSource>());
+            GameObject.DestroyImmediate(clonedImage.GetComponent<AudioManager>());
+            clonedImage.rectTransform.SetParent(baldiImage.transform.parent, true);
+            baldiImage.enabled = false;
             clonedImage.transform.SetAsFirstSibling();
             // get a raw enumerator and pass that into the container ienumerator, and return that ienumerator
             return CharacterEnumeratorContainer(tv, clonedImage, GetRawCharacterEnumerator(id, tv, clonedImage, sound));
@@ -168,7 +170,7 @@ namespace MTM101BaldAPI.PlusExtensions
             }
             anim.image = image;
             volAnim.animator = anim;
-            volAnim.audioSource = audMan.audioDevice;
+            volAnim.audioSource = audMan.audioSourceManager.GetAudioSource(sound.soundType);
             volAnim.sensitivity = sensitivity;
             volAnim.volumeMultipler = volumeMultiplier;
             audMan.QueueAudio(sound);


### PR DESCRIPTION
Fixes a major bug where the audio manager's awake component gets called all because this script gets loaded upon creation. (Which this bug will also cause overlapping audio clips to play and the currently playing audio clip replays)

A simple fix is that I set the game object's parent to the prefab transform where I get rid of the components from the baldi image game object where the `Awake()` function never gets called because it is not loaded at all! How convenient of me!