### PR TITLE
The Ability to Import GLTF/GLB Files with UnityGLTF

### DIFF
--- a/MTM101BMDE/AssetTools/AssetLoader.cs
+++ b/MTM101BMDE/AssetTools/AssetLoader.cs
@@ -178,10 +178,20 @@ namespace MTM101BaldAPI.AssetTools
                 KeepCPUCopyOfTexture = true,
             })
             {
-                import.CustomShaderName = MTM101BaldiDevAPI.AssetMan.Get<Material>("TileBase").shader.name;
+                import.SceneParent = MTM101BaldiDevAPI.prefabTransform;
+                var mat = MTM101BaldiDevAPI.AssetMan.Get<Material>("TileBase");
+                import.CustomShaderName = mat.shader.name;
                 var obj = new InstantiatedGLTFObject[1]; // Worst part is that it took me almost 12 hours for a reasonable working result.
-                import.LoadScene(onLoadComplete: (gObj, task) => obj[0] = gObj.GetComponent<InstantiatedGLTFObject>());
-                MTM101BaldiDevAPI.Log.LogInfo("It imported!!");
+                import.LoadScene(onLoadComplete: (gObj, task) =>
+                {
+                    obj[0] = gObj.GetComponent<InstantiatedGLTFObject>();
+                    obj[0].gameObject.name = filename;
+                    obj[0].CachedData.MaterialCache.Do(x =>
+                    {
+                        x.GetContents(false).SetTexture("_LightMap", mat.GetTexture("_LightMap"));
+                        x.GetContents(true).SetTexture("_LightMap", mat.GetTexture("_LightMap"));
+                    });
+                });
                 return obj;
             }
         }

--- a/MTM101BMDE/AssetTools/AssetLoader.cs
+++ b/MTM101BMDE/AssetTools/AssetLoader.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
-using UnityEngine.Networking;
-using System.IO;
-using BepInEx;
-using System.Linq;
-using MidiPlayerTK;
-using MPTK.NAudio.Midi;
+﻿using BepInEx;
 using HarmonyLib;
 using MEC;
-using System.Reflection;
+using MidiPlayerTK;
 using MTM101BaldAPI.OBJImporter;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 using TMPro;
+using UnityEngine;
+using UnityEngine.Networking;
 using UnityEngine.TextCore.LowLevel;
+using UnityGLTF;
+using UnityGLTF.Loader;
 
 namespace MTM101BaldAPI.AssetTools
 {
@@ -148,6 +148,54 @@ namespace MTM101BaldAPI.AssetTools
             List<string> pathz = paths.ToList();
             pathz.Insert(0, GetModPath(plugin));
             return ModelFromFileManualMaterials(Path.Combine(pathz.ToArray()), materials);
+        }
+
+        /// <summary>
+        /// Loads a .gltf or .glb model the specified file. Note that this must be called on a IEnumerator or it will skip the next frame.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static InstantiatedGLTFObject[] GLTFModelFromFile(string path)
+        {
+            string filename = Path.GetFileName(path), directorypath = Path.GetFullPath(path).Replace(filename, "");
+            //MTM101BaldiDevAPI.Log.LogInfo($"Loading GLTF model {filename} from {directorypath}!");
+            ImportOptions importOpt = new ImportOptions
+            {
+                AsyncCoroutineHelper = MTM101BaldiDevAPI.Instance.gameObject.GetOrAddComponent<AsyncCoroutineHelper>(),
+                ImportNormals = GLTFImporterNormals.Import,
+                ImportTangents = GLTFImporterNormals.Import,
+                RuntimeTextureCompression = RuntimeTextureCompression.None,
+                SwapUVs = false,
+                ImportBlendShapeNames = true,
+                CameraImport = CameraImportOption.None,
+                AnimationMethod = AnimationMethod.Legacy
+            };
+            importOpt.DataLoader = new UnityWebRequestLoader(directorypath);
+            using (var import = new GLTFSceneImporter(filename, importOpt)
+            {
+                Collider = GLTFSceneImporter.ColliderType.None,
+                KeepCPUCopyOfMesh = true,
+                KeepCPUCopyOfTexture = true,
+            })
+            {
+                import.CustomShaderName = MTM101BaldiDevAPI.AssetMan.Get<Material>("TileBase").shader.name;
+                var obj = new InstantiatedGLTFObject[1]; // Worst part is that it took me almost 12 hours for a reasonable working result.
+                import.LoadScene(onLoadComplete: (gObj, task) => obj[0] = gObj.GetComponent<InstantiatedGLTFObject>());
+                MTM101BaldiDevAPI.Log.LogInfo("It imported!!");
+                return obj;
+            }
+        }
+        /// <summary>
+        /// Loads a .gltf or .glb model the specified mod. Note that this must be called on a IEnumerator or it will skip the next frame.
+        /// </summary>
+        /// <param name="plugin"></param>
+        /// <param name="paths"></param>
+        /// <returns></returns>
+        public static InstantiatedGLTFObject[] GLTFModelFromMod(PluginInfo plugin, params string[] paths)
+        {
+            List<string> pathz = paths.ToList();
+            pathz.Insert(0, GetModPath(plugin.Instance));
+            return GLTFModelFromFile(Path.Combine(pathz.ToArray()));
         }
 
 

--- a/MTM101BMDE/BasePlugin.cs
+++ b/MTM101BMDE/BasePlugin.cs
@@ -1,37 +1,39 @@
-﻿using System;
+﻿//BepInEx stuff
+using BepInEx;
+using BepInEx.Bootstrap;
+using BepInEx.Configuration;
+using BepInEx.Logging;
+using HarmonyLib;
+using MidiPlayerTK;
+using MTM101BaldAPI.AssetTools;
+using MTM101BaldAPI.Components;
+using MTM101BaldAPI.ErrorHandler;
+using MTM101BaldAPI.ObjectCreation;
+using MTM101BaldAPI.OptionsAPI;
+using MTM101BaldAPI.Patches;
+using MTM101BaldAPI.Reflection;
+using MTM101BaldAPI.Registers;
+using MTM101BaldAPI.SaveSystem;
+using MTM101BaldAPI.UI;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Net;
-//BepInEx stuff
-using BepInEx;
-using BepInEx.Logging;
-using UnityEngine;
-using UnityEngine.SceneManagement;
-using HarmonyLib;
-using BepInEx.Configuration;
-using System.Linq;
-using System.Collections.Generic;
-using MTM101BaldAPI.OptionsAPI;
-using MTM101BaldAPI.SaveSystem;
-using System.IO;
-using MTM101BaldAPI.Registers;
-using MTM101BaldAPI.AssetTools;
-using UnityCipher;
-using MTM101BaldAPI.Reflection;
-using TMPro;
-using System.Collections;
-using MTM101BaldAPI.UI;
-using UnityEngine.UI;
-using MidiPlayerTK;
-using MTM101BaldAPI.Patches;
-using MTM101BaldAPI.Components;
 using System.Runtime.InteropServices;
+using TMPro;
+using UnityCipher;
+using UnityEngine;
 using UnityEngine.Networking;
-using Newtonsoft.Json.Linq;
-using MTM101BaldAPI.ErrorHandler;
-using System.Linq.Expressions;
-using BepInEx.Bootstrap;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using UnityGLTF;
 
 namespace MTM101BaldAPI
 {
@@ -722,7 +724,6 @@ namespace MTM101BaldAPI
             }
 
             // setup loading for default crazy machines
-
         }
 
         internal void ConvertAllLevelObjects()
@@ -916,6 +917,13 @@ PRESS ALT+F4 TO EXIT THE GAME.
                 AddWarningScreen("Newtonsoft.Json is not installed! It should be included with the API zip!", true);
             }
             else */
+            try
+            {
+            }
+            catch
+            {
+                AddWarningScreen("UnityGLTF plugins are not installed correctly. It is included in the mod download and should go in plugins. Install it correctly and stop following obsoleted tutorials.", true);
+            }
             if (attemptOnline.Value)
             {
                 StartCoroutine(GetCurrentGamebananaVersion());
@@ -924,6 +932,55 @@ PRESS ALT+F4 TO EXIT THE GAME.
             //set window title
             if (allowWindowTitleChange.Value)
                 WindowTitle.SetText(Application.productName + " (Modded)");
+#if DEBUG
+            IEnumerator TestEnumerator()
+            {
+                yield return 2;
+                yield return "Test";
+                // GLTF loader and animator as code test (Well we can not call it on `AssetsLoadPre` since it gets called when the scene is unloaded.)
+                var data = AssetLoader.GLTFModelFromFile(Path.Combine(Application.streamingAssetsPath, "TestHumanoidRig.glb"));
+                yield return new WaitUntil(() => data[0] != null);
+                var myman = data[0];
+                var cawl = myman.GetComponent<Animation>();
+                cawl.wrapMode = WrapMode.Loop;
+                cawl.Play("CrawlForward");
+                /*try
+                {
+                    var animator = myman.GetOrAddComponent<Animator>();
+                    var root = myman.transform.GetChild(0).Find("Root");
+                    animator.avatar = new AvatarRigBuilder(myman)
+                        .AutomaticSetBones()
+                        .SetBone(HumanBodyBones.LeftUpperLeg, root.GetChild(0).Find("thigh.L"))
+                        .SetBone(HumanBodyBones.LeftLowerLeg, root.GetChild(0).Find("thigh.L").GetChild(0))
+                        .SetBone(HumanBodyBones.LeftFoot, root.GetChild(0).Find("thigh.L").GetChild(0).GetChild(0))
+                        .SetBone(HumanBodyBones.RightUpperLeg, root.GetChild(0).Find("thigh.R"))
+                        .SetBone(HumanBodyBones.RightLowerLeg, root.GetChild(0).Find("thigh.R").GetChild(0))
+                        .SetBone(HumanBodyBones.RightFoot, root.GetChild(0).Find("thigh.R").GetChild(0).GetChild(0))
+                        .SetBone(HumanBodyBones.LeftUpperArm, root.GetChild(0).Find("Spine").GetChild(0).Find("shoulder.L"))
+                        .SetBone(HumanBodyBones.LeftLowerArm, root.GetChild(0).Find("Spine").GetChild(0).Find("shoulder.L").GetChild(0))
+                        .SetBone(HumanBodyBones.LeftHand, root.GetChild(0).Find("Spine").GetChild(0).Find("shoulder.L").GetChild(0).GetChild(0))
+                        .SetBone(HumanBodyBones.RightUpperArm, root.GetChild(0).Find("Spine").GetChild(0).Find("shoulder.R"))
+                        .SetBone(HumanBodyBones.RightLowerArm, root.GetChild(0).Find("Spine").GetChild(0).Find("shoulder.R").GetChild(0))
+                        .SetBone(HumanBodyBones.RightHand, root.GetChild(0).Find("Spine").GetChild(0).Find("shoulder.R").GetChild(0).GetChild(0))
+                        .Build();
+                    animator.avatar.name = "ABWAvatar";
+                    var animatorcontrollercode = ScriptableObject.CreateInstance<AnimatorControllerCode>();
+                    var mylayer = new AnimationLayer("Base");
+                    var myanimdata = new AnimationData(data[0].CachedData.AnimationCache.First(x => x.LoadedAnimationClip.name == "Crawl").LoadedAnimationClip);
+                    mylayer.entryState = myanimdata;
+                    mylayer.animationDatas.Add(myanimdata);
+                    animatorcontrollercode.layers = new HashSet<AnimationLayer>() { mylayer };
+                    // Requiring of publicization
+                    animatorcontrollercode.ReflectionInvoke("Generate", new object[] { AccessTools.Constructor(typeof(Acc), new Type[] { typeof(string), typeof(AnimatorController), typeof(AccConfig) }).Invoke(new object[] { "Main", new RuntimeAnimatorController(), new AccConfig(myman.transform) }) });
+
+                }
+                catch (Exception e)
+                {
+                    CauseCrash(Info, e);
+                }*/
+            }
+            LoadingEvents.RegisterOnAssetsLoaded(Info, TestEnumerator(), LoadingEventOrder.Start);
+#endif
         }
 
         void TestForNewton()

--- a/MTM101BMDE/BasePlugin.cs
+++ b/MTM101BMDE/BasePlugin.cs
@@ -940,7 +940,8 @@ PRESS ALT+F4 TO EXIT THE GAME.
                 // GLTF loader and animator as code test (Well we can not call it on `AssetsLoadPre` since it gets called when the scene is unloaded.)
                 var data = AssetLoader.GLTFModelFromFile(Path.Combine(Application.streamingAssetsPath, "TestHumanoidRig.glb"));
                 yield return new WaitUntil(() => data[0] != null);
-                var myman = data[0];
+                var myman = data[0].Duplicate();
+                DontDestroyOnLoad(myman);
                 var cawl = myman.GetComponent<Animation>();
                 cawl.wrapMode = WrapMode.Loop;
                 cawl.Play("CrawlForward");


### PR DESCRIPTION
This seems reasonable but also requires knowledge of the `WaitUntil()` yield constructor because the importer uses async functions. (There is no problem with yield returning a thing that is not a string but standard sync functions can not do such thing if tried as the imported model will be done in the next frame.)

What I did possibly test for this is animation clips and automatic material importing from the `.glb`/`.gltf` file. Animation clips are successfully imported from the file (exported from Blender) and the materials are automatically created into Unity materials from the file, although the `Animation` component is used for legacy animation clips, it serves reasonable mods that can be created such as "OpenGL Mode" which similar to SRB2's setting that requires OpenGL to be the preferred 3D renderer, transforms entities (if their model is available) from 2D sprite renderers to 3D mesh renderers which can cause odd feelings but is one of the reasons why I wanted to implement a new model importer.

This does not mean it will obsolete the `.obj` and `.mtl` loaders, the `.gltf`/`.glb` loaders are meant for advanced use.

I have the assembly files (UnityGLTF assemblies that are dependencies for this branch) necessary for this implementation to work, [UnityGLTF loader also uses the MIT license](https://github.com/KhronosGroup/UnityGLTF?tab=MIT-1-ov-file) which makes distributing the assembly files in the package an option.